### PR TITLE
feat(ODC-399): add GitLab support for build tool and language detector

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -597,6 +597,14 @@
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:660578a0b729bd1a8b7896a8b390979659000400f4007c659c77165ae48da445"
+  name = "github.com/xanzy/go-gitlab"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "be70cf752294cc5c6ee89a18d6ba0caca08aa5c7"
+  version = "v0.16.1"
+
+[[projects]]
   digest = "1:3148cb3478c26a92b4c1a18abb9428234b281e278af6267840721a24b6cbc6a3"
   name = "github.com/xanzy/ssh-agent"
   packages = ["."]
@@ -1237,6 +1245,7 @@
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "github.com/xanzy/go-gitlab",
     "golang.org/x/crypto/ssh",
     "golang.org/x/oauth2",
     "gopkg.in/h2non/gock.v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -82,6 +82,10 @@ required = [
   name = "github.com/google/go-github"
   version = "v24.0.1"
 
+[[override]]
+  name = "github.com/xanzy/go-gitlab"
+  version = "v0.16.1"
+
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "v1.3.0"

--- a/pkg/git/detector/detector.go
+++ b/pkg/git/detector/detector.go
@@ -5,6 +5,7 @@ import (
 	"github.com/redhat-developer/git-service/pkg/apis/devconsole/v1alpha1"
 	"github.com/redhat-developer/git-service/pkg/git"
 	"github.com/redhat-developer/git-service/pkg/git/repository"
+	"github.com/redhat-developer/git-service/pkg/git/repository/gitlab"
 	"regexp"
 	"sync"
 
@@ -13,6 +14,7 @@ import (
 
 var gitServiceCreators = []repository.ServiceCreator{
 	github.NewRepoServiceIfMatches(),
+	gitlab.NewRepoServiceIfMatches(),
 }
 
 func DetectBuildEnvironments(gitSource *v1alpha1.GitSource, secret git.Secret) (*BuildEnvStats, error) {

--- a/pkg/git/detector/detector.go
+++ b/pkg/git/detector/detector.go
@@ -17,6 +17,7 @@ var gitServiceCreators = []repository.ServiceCreator{
 	gitlab.NewRepoServiceIfMatches(),
 }
 
+// DetectBuildEnvironments detects build tools and languages in the git repository defined by the given v1alpha1.GitSource
 func DetectBuildEnvironments(gitSource *v1alpha1.GitSource, secret git.Secret) (*BuildEnvStats, error) {
 	return detectBuildEnvs(gitSource, secret, gitServiceCreators)
 }

--- a/pkg/git/detector/detector_whitebox_test.go
+++ b/pkg/git/detector/detector_whitebox_test.go
@@ -88,7 +88,7 @@ func XTestGitLabDetectorWithUsernamePassword(t *testing.T) {
 
 	glSource := test.NewGitSource(test.WithURL("https://gitlab.com/gitlab-org/gitlab-qa"))
 
-	buildEnvStats, err := DetectBuildEnvironments(glSource, git.NewUsernamePassword("anonymous", ""))
+	buildEnvStats, err := DetectBuildEnvironments(glSource, git.NewUsernamePassword("", ""))
 	require.NoError(t, err)
 	printBuildEnvStats(buildEnvStats)
 }

--- a/pkg/git/detector/detector_whitebox_test.go
+++ b/pkg/git/detector/detector_whitebox_test.go
@@ -67,7 +67,7 @@ func TestGitLabDetectorWithToken(t *testing.T) {
 	require.Len(t, buildEnvStats.DetectedBuildTools, 1)
 	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTools, Maven, "pom.xml")
 	require.Len(t, buildEnvStats.SortedLanguages, 1)
-	assert.Equal(t, buildEnvStats.SortedLanguages[0], "Java")
+	assert.Equal(t, "Java", buildEnvStats.SortedLanguages[0])
 }
 
 // ignored tests as they reach the real services or needs specific credentials

--- a/pkg/git/detector/detector_whitebox_test.go
+++ b/pkg/git/detector/detector_whitebox_test.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 	"github.com/redhat-developer/git-service/pkg/test"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -54,7 +55,22 @@ func TestFailingGetLanguagesList(t *testing.T) {
 	require.Nil(t, buildEnvStats)
 }
 
-// ignored tests as they reach the real services
+func TestGitLabDetectorWithToken(t *testing.T) {
+	// given
+	glSource := test.NewGitSource(test.WithURL("https://gitlab.com/matousjobanek/quarkus-knative"))
+
+	// when
+	buildEnvStats, err := DetectBuildEnvironments(glSource, git.NewOauthToken([]byte("")))
+
+	// then
+	require.NoError(t, err)
+	require.Len(t, buildEnvStats.DetectedBuildTools, 1)
+	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTools, Maven, "pom.xml")
+	require.Len(t, buildEnvStats.SortedLanguages, 1)
+	assert.Equal(t, buildEnvStats.SortedLanguages[0], "Java")
+}
+
+// ignored tests as they reach the real services or needs specific credentials
 
 func XTestGitHubDetectorWithToken(t *testing.T) {
 	token, err := ioutil.ReadFile(homeDir + "/.github-auth")
@@ -71,15 +87,6 @@ func XTestGitHubDetectorWithUsernameAndPassword(t *testing.T) {
 	ghSource := test.NewGitSource(test.WithURL("https://github.com/wildfly/wildfly"))
 
 	buildEnvStats, err := DetectBuildEnvironments(ghSource, git.NewUsernamePassword("anonymous", ""))
-	require.NoError(t, err)
-	printBuildEnvStats(buildEnvStats)
-}
-
-func XTestGitLabDetectorWithToken(t *testing.T) {
-
-	glSource := test.NewGitSource(test.WithURL("https://gitlab.com/gitlab-org/gitlab-qa"))
-
-	buildEnvStats, err := DetectBuildEnvironments(glSource, git.NewOauthToken([]byte("")))
 	require.NoError(t, err)
 	printBuildEnvStats(buildEnvStats)
 }

--- a/pkg/git/detector/detector_whitebox_test.go
+++ b/pkg/git/detector/detector_whitebox_test.go
@@ -75,6 +75,24 @@ func XTestGitHubDetectorWithUsernameAndPassword(t *testing.T) {
 	printBuildEnvStats(buildEnvStats)
 }
 
+func XTestGitLabDetectorWithToken(t *testing.T) {
+
+	glSource := test.NewGitSource(test.WithURL("https://gitlab.com/gitlab-org/gitlab-qa"))
+
+	buildEnvStats, err := DetectBuildEnvironments(glSource, git.NewOauthToken([]byte("")))
+	require.NoError(t, err)
+	printBuildEnvStats(buildEnvStats)
+}
+
+func XTestGitLabDetectorWithUsernamePassword(t *testing.T) {
+
+	glSource := test.NewGitSource(test.WithURL("https://gitlab.com/gitlab-org/gitlab-qa"))
+
+	buildEnvStats, err := DetectBuildEnvironments(glSource, git.NewUsernamePassword("anonymous", ""))
+	require.NoError(t, err)
+	printBuildEnvStats(buildEnvStats)
+}
+
 func printBuildEnvStats(buildEnvStats *BuildEnvStats) {
 	fmt.Println(buildEnvStats.SortedLanguages)
 	for _, build := range buildEnvStats.DetectedBuildTools {

--- a/pkg/git/langs.go
+++ b/pkg/git/langs.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 )
 
+// SortLanguagesWithInts sorts languages from the given map to a slice where the first one is with the highest number
 func SortLanguagesWithInts(langsWithSizes map[string]int) []string {
 	var contentSizes []string
 	reversedMap := map[string]string{}
@@ -16,6 +17,7 @@ func SortLanguagesWithInts(langsWithSizes map[string]int) []string {
 	return sortLanguages(contentSizes, reversedMap)
 }
 
+// SortLanguagesWithFloats32 sorts languages from the given map to a slice where the first one is with the highest number
 func SortLanguagesWithFloats32(langsWithSizes map[string]float32) []string {
 	var contentSizes []string
 	reversedMap := map[string]string{}

--- a/pkg/git/repository/github/service.go
+++ b/pkg/git/repository/github/service.go
@@ -21,6 +21,8 @@ type RepositoryService struct {
 	filenames []string
 }
 
+// NewRepoServiceIfMatches returns function creating Github repository service if either host of the git repo URL is github.com
+// or flavor of the given git source is github then, nil otherwise
 func NewRepoServiceIfMatches() repository.ServiceCreator {
 	return func(gitSource *v1alpha1.GitSource, secret git.Secret) (repository.GitService, error) {
 		endpoint, err := gittransport.NewEndpoint(gitSource.Spec.URL)

--- a/pkg/git/repository/gitlab/service.go
+++ b/pkg/git/repository/gitlab/service.go
@@ -18,6 +18,8 @@ type RepositoryService struct {
 	repo   repository.StructuredIdentifier
 }
 
+// NewRepoServiceIfMatches returns function creating Github repository service if either host of the git repo URL is gitlab.com
+// or flavor of the given git source is gitlab then, nil otherwise
 func NewRepoServiceIfMatches() repository.ServiceCreator {
 	return func(gitSource *v1alpha1.GitSource, secret git.Secret) (repository.GitService, error) {
 		endpoint, err := gittransport.NewEndpoint(gitSource.Spec.URL)

--- a/pkg/git/repository/gitlab/service.go
+++ b/pkg/git/repository/gitlab/service.go
@@ -1,0 +1,81 @@
+package gitlab
+
+import (
+	"github.com/redhat-developer/git-service/pkg/apis/devconsole/v1alpha1"
+	"github.com/redhat-developer/git-service/pkg/git"
+	"github.com/redhat-developer/git-service/pkg/git/repository"
+	gogl "github.com/xanzy/go-gitlab"
+	gittransport "gopkg.in/src-d/go-git.v4/plumbing/transport"
+)
+
+const (
+	gitlabHost   = "gitlab.com"
+	gitlabFlavor = "gitlab"
+)
+
+type RepositoryService struct {
+	client *gogl.Client
+	repo   repository.StructuredIdentifier
+}
+
+func NewRepoServiceIfMatches() repository.ServiceCreator {
+	return func(gitSource *v1alpha1.GitSource, secret git.Secret) (repository.GitService, error) {
+		endpoint, err := gittransport.NewEndpoint(gitSource.Spec.URL)
+		if err != nil {
+			return nil, err
+		}
+
+		if endpoint.Host == gitlabHost || gitSource.Spec.Flavor == gitlabFlavor {
+			return newGhClient(gitSource, secret, endpoint)
+		}
+		return nil, nil
+	}
+}
+
+func newGhClient(gitSource *v1alpha1.GitSource, secret git.Secret, endpoint *gittransport.Endpoint) (*RepositoryService, error) {
+	repo, err := repository.NewStructuredIdentifier(gitSource, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	client := gogl.NewOAuthClient(secret.Client(), secret.SecretContent())
+	if secret.SecretType() == git.UsernamePasswordType {
+		username, password := git.ParseUsernameAndPassword(secret.SecretContent())
+		shortUrl := *endpoint
+		shortUrl.Path = ""
+		client, err = gogl.NewBasicAuthClient(secret.Client(), shortUrl.String(), username, password)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &RepositoryService{
+		client: client,
+		repo:   repo,
+	}, nil
+}
+
+func (s *RepositoryService) GetListOfFilesInRootDir() ([]string, error) {
+	tree, _, err := s.client.Repositories.ListTree(
+		s.repo.OwnerWithName(),
+		&gogl.ListTreeOptions{
+			Ref: &s.repo.Branch,
+		})
+	if err != nil {
+		return nil, err
+	}
+	var filenames []string
+	for _, entry := range tree {
+		filenames = append(filenames, entry.Path)
+	}
+	return filenames, nil
+}
+
+func (s *RepositoryService) GetLanguageList() ([]string, error) {
+	languages, _, err := s.client.Projects.GetProjectLanguages(s.repo.OwnerWithName())
+	if err != nil {
+		return nil, err
+	}
+
+	return git.SortLanguagesWithFloats32(*languages), nil
+}

--- a/pkg/git/repository/gitlab/service_test.go
+++ b/pkg/git/repository/gitlab/service_test.go
@@ -1,0 +1,178 @@
+package gitlab_test
+
+import (
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"github.com/redhat-developer/git-service/pkg/git"
+	"github.com/redhat-developer/git-service/pkg/git/repository/gitlab"
+	"github.com/redhat-developer/git-service/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gogl "github.com/xanzy/go-gitlab"
+	"golang.org/x/oauth2"
+	"gopkg.in/h2non/gock.v1"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+const (
+	repoIdentifier = "some-org/some-repo"
+	repoURL        = "https://gitlab.com/" + repoIdentifier
+	notFound       = `{"message":"404 Project Not Found"}`
+)
+
+func TestRepositoryServiceForBothAuthMethodsSuccessful(t *testing.T) {
+	// given
+	defer gock.OffAll()
+	usernamePassword := git.NewUsernamePassword("anonymous", "")
+	oauthToken := git.NewOauthToken([]byte("some-token"))
+	mockTokenCall(t)
+
+	for _, secret := range []git.Secret{usernamePassword, oauthToken} {
+		mockGLCalls(t, repoIdentifier, "master", test.S("pom.xml", "mvnw"), test.S("Java", "Go"))
+		source := test.NewGitSource(test.WithURL(repoURL))
+
+		// when
+		service, err := gitlab.NewRepoServiceIfMatches()(source, secret)
+
+		// then
+		require.NoError(t, err)
+
+		filesInRootDir, err := service.GetListOfFilesInRootDir()
+		require.NoError(t, err)
+		require.Len(t, filesInRootDir, 2)
+		assert.Contains(t, filesInRootDir, "pom.xml")
+		assert.Contains(t, filesInRootDir, "mvnw")
+
+		languageList, err := service.GetLanguageList()
+		require.NoError(t, err)
+		require.Len(t, languageList, 2)
+		assert.Contains(t, languageList, "Java")
+		assert.Contains(t, languageList, "Go")
+	}
+}
+
+func TestNewRepoServiceIfMatchesShouldNotMatchWhenGitLabHost(t *testing.T) {
+	// given
+	source := test.NewGitSource(test.WithURL("gitlab.com/" + repoIdentifier))
+
+	// when
+	service, err := gitlab.NewRepoServiceIfMatches()(source, git.NewOauthToken([]byte("some-token")))
+
+	// then
+	assert.NoError(t, err)
+	assert.Nil(t, service)
+}
+
+func TestNewRepoServiceIfMatchesShouldMatchWhenFlavorIsGitHub(t *testing.T) {
+	// given
+	source := test.NewGitSource(test.WithURL("gitprivatelab.com/"+repoIdentifier), test.WithFlavor("gitlab"))
+
+	// when
+	service, err := gitlab.NewRepoServiceIfMatches()(source, git.NewOauthToken([]byte("some-token")))
+
+	// then
+	assert.NoError(t, err)
+	assert.NotNil(t, service)
+}
+
+func TestNewRepoServiceIfMatchesShouldNotFailWhenSsh(t *testing.T) {
+	// given
+	source := test.NewGitSource(test.WithURL("git@gitlab.com:" + repoIdentifier))
+
+	// when
+	service, err := gitlab.NewRepoServiceIfMatches()(source, git.NewOauthToken([]byte("some-token")))
+
+	// then
+	assert.NoError(t, err)
+	assert.NotNil(t, service)
+}
+
+func TestRepositoryServiceForWrongRepo(t *testing.T) {
+	// given
+	defer gock.OffAll()
+	usernamePassword := git.NewUsernamePassword("anonymous", "")
+	oauthToken := git.NewOauthToken([]byte("some-token"))
+	mockTokenCall(t)
+
+	for _, secret := range []git.Secret{usernamePassword, oauthToken} {
+		gock.New("https://gitlab.com").
+			Get(fmt.Sprintf("/api/v4/projects/%s/", repoIdentifier)).
+			Times(2).
+			Reply(404).
+			BodyString(notFound)
+		source := test.NewGitSource(test.WithURL(repoURL), test.WithRef("dev"))
+
+		// when
+		service, err := gitlab.NewRepoServiceIfMatches()(source, secret)
+
+		// then
+		require.NoError(t, err)
+
+		filesInRootDir, err := service.GetListOfFilesInRootDir()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Not Found")
+		require.Len(t, filesInRootDir, 0)
+
+		languageList, err := service.GetLanguageList()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Not Found")
+		require.Len(t, languageList, 0)
+	}
+}
+
+func mockTokenCall(t *testing.T) {
+	token := &oauth2.Token{
+		AccessToken: "some-token",
+		TokenType:   "bearer",
+	}
+	bytes, err := json.Marshal(token)
+	require.NoError(t, err)
+	gock.New("https://gitlab.com").
+		Post("/oauth/token").
+		Reply(200).
+		BodyString(string(bytes))
+}
+
+func mockGLCalls(t *testing.T, prjPath, branch string, files, langs test.SliceOfStrings) {
+	var treeNodes []gogl.TreeNode
+	for _, file := range files() {
+		treeNodes = append(treeNodes, gogl.TreeNode{
+			ID:   *sha(file),
+			Path: file,
+			Name: file,
+		})
+	}
+
+	bytes, err := json.Marshal(treeNodes)
+	require.NoError(t, err)
+
+	gock.New("https://gitlab.com").
+		Get(fmt.Sprintf("/api/v4/projects/%s/repository/tree", prjPath)).
+		MatchParam("ref", branch).
+		Reply(200).
+		BodyString(string(bytes))
+
+	languages := map[string]float32{}
+	for _, lang := range langs() {
+		languages[lang] = rand.Float32()
+	}
+
+	bytes, err = json.Marshal(languages)
+	require.NoError(t, err)
+
+	gock.New("https://gitlab.com").
+		Get(fmt.Sprintf("/api/v4/projects/%s/languages", prjPath)).
+		Reply(200).
+		BodyString(string(bytes))
+}
+
+func sha(files ...string) *string {
+	return String(string(sha1.New().Sum([]byte(strings.Join(files, "-")))))
+}
+
+func String(value string) *string {
+	return &value
+}

--- a/pkg/git/repository/identifier.go
+++ b/pkg/git/repository/identifier.go
@@ -10,12 +10,14 @@ import (
 
 const Master = "master"
 
+// StructuredIdentifier is an identifier of git repository that consist of a owner, name and branch
 type StructuredIdentifier struct {
 	Owner  string
 	Name   string
 	Branch string
 }
 
+// NewStructuredIdentifier returns an instance of the StructuredIdentifier for the given v1alpha1.GitSource
 func NewStructuredIdentifier(gitSource *v1alpha1.GitSource, endpoint *gittransport.Endpoint) (StructuredIdentifier, error) {
 	var repo StructuredIdentifier
 	branch := Master
@@ -49,6 +51,7 @@ func NewStructuredIdentifier(gitSource *v1alpha1.GitSource, endpoint *gittranspo
 	}
 }
 
+// OwnerWithName joins owner and name by a slash
 func (i StructuredIdentifier) OwnerWithName() string {
 	return fmt.Sprintf("%s/%s", i.Owner, i.Name)
 }

--- a/pkg/git/repository/service.go
+++ b/pkg/git/repository/service.go
@@ -6,12 +6,16 @@ import (
 )
 
 type GitService interface {
+	// GetListOfFilesInRootDir returns list of filenames present in the root directory
 	GetListOfFilesInRootDir() ([]string, error)
+	// GetLanguageList returns list of detected languages in the sorted order where the first one is the most used
 	GetLanguageList() ([]string, error)
 }
 
+// ServiceCreator creates an instance of GitService for the given v1alpha1.GitSource
 type ServiceCreator func(gitSource *v1alpha1.GitSource, secret git.Secret) (GitService, error)
 
+// NewGitService returns an instance of GitService for the given v1alpha1.GitSource. If no service is matched then returns nil
 func NewGitService(gitSource *v1alpha1.GitSource, secret git.Secret, serviceCreators []ServiceCreator) (GitService, error) {
 
 	for _, creator := range serviceCreators {

--- a/pkg/git/secret.go
+++ b/pkg/git/secret.go
@@ -15,9 +15,13 @@ import (
 )
 
 type Secret interface {
+	// GitAuthMethod returns an instance of git AuthMethod for the secret
 	GitAuthMethod() (transport.AuthMethod, error)
+	// Client returns an instance of http.Client for the secret
 	Client() *http.Client
+	// SecretType returns a type of the secret
 	SecretType() string
+	// SecretContent returns an actual content of the secret
 	SecretContent() string
 }
 


### PR DESCRIPTION
Adds support for GitLab repositories to build tool and language detector. 
GitLab service is chosen when a repository URL has `gitlab.com` as its host or `GitSource.Flavor` equals to `gitlab`. 
GitLab service supports both auth methods OAuth token and the basic one 