### PR TITLE
fix: sort languages correctly-by numbers not strings

### DIFF
--- a/pkg/git/langs.go
+++ b/pkg/git/langs.go
@@ -1,40 +1,44 @@
 package git
 
 import (
-	"fmt"
 	"sort"
 )
 
 // SortLanguagesWithInts sorts languages from the given map to a slice where the first one is with the highest number
 func SortLanguagesWithInts(langsWithSizes map[string]int) []string {
-	var contentSizes []string
-	reversedMap := map[string]string{}
+	var contentSizes []int
+	reversedMap := make(map[int][]string)
 	for lang, size := range langsWithSizes {
-		key := fmt.Sprintf("%d_%s", size, lang)
-		reversedMap[key] = lang
-		contentSizes = append(contentSizes, key)
+		if _, ok := reversedMap[size]; !ok {
+			contentSizes = append(contentSizes, size)
+		}
+		reversedMap[size] = append(reversedMap[size], lang)
 	}
-	return sortLanguages(contentSizes, reversedMap)
+	sort.Ints(contentSizes)
+
+	var sortedLangs []string
+	for i := len(contentSizes) - 1; i >= 0; i-- {
+		sortedLangs = append(sortedLangs, reversedMap[contentSizes[i]]...)
+	}
+	return sortedLangs
 }
 
 // SortLanguagesWithFloats32 sorts languages from the given map to a slice where the first one is with the highest number
 func SortLanguagesWithFloats32(langsWithSizes map[string]float32) []string {
-	var contentSizes []string
-	reversedMap := map[string]string{}
-	for lang, size := range langsWithSizes {
-		key := fmt.Sprintf("%f_%s", size, lang)
-		reversedMap[key] = lang
-		contentSizes = append(contentSizes, key)
+	var contentSizes []float64
+	reversedMap := make(map[float64][]string)
+	for lang, size32 := range langsWithSizes {
+		size := float64(size32)
+		if _, ok := reversedMap[size]; !ok {
+			contentSizes = append(contentSizes, size)
+		}
+		reversedMap[size] = append(reversedMap[size], lang)
 	}
-	return sortLanguages(contentSizes, reversedMap)
-}
-
-func sortLanguages(contentSizes []string, reversedMap map[string]string) []string {
-	sort.Strings(contentSizes)
+	sort.Float64s(contentSizes)
 
 	var sortedLangs []string
 	for i := len(contentSizes) - 1; i >= 0; i-- {
-		sortedLangs = append(sortedLangs, reversedMap[contentSizes[i]])
+		sortedLangs = append(sortedLangs, reversedMap[contentSizes[i]]...)
 	}
 	return sortedLangs
 }

--- a/pkg/git/langs.go
+++ b/pkg/git/langs.go
@@ -5,40 +5,42 @@ import (
 )
 
 // SortLanguagesWithInts sorts languages from the given map to a slice where the first one is with the highest number
-func SortLanguagesWithInts(langsWithSizes map[string]int) []string {
-	var contentSizes []int
-	reversedMap := make(map[int][]string)
-	for lang, size := range langsWithSizes {
-		if _, ok := reversedMap[size]; !ok {
-			contentSizes = append(contentSizes, size)
-		}
-		reversedMap[size] = append(reversedMap[size], lang)
+func SortLanguagesWithInts(languages map[string]int) []string {
+	var langsWithRatio []langWithRatio
+	for lang, ratio := range languages {
+		langsWithRatio = append(langsWithRatio, langWithRatio{ratio: float64(ratio), lang: lang})
 	}
-	sort.Ints(contentSizes)
+	return sortLangs(langsWithRatio)
+}
+
+// SortLanguagesWithFloats32 sorts languages from the given map to a slice where the first one is with the highest number
+func SortLanguagesWithFloats32(languages map[string]float32) []string {
+	var langsWithRatio []langWithRatio
+	for lang, ratio := range languages {
+		langsWithRatio = append(langsWithRatio, langWithRatio{ratio: float64(ratio), lang: lang})
+	}
+	return sortLangs(langsWithRatio)
+}
+
+func sortLangs(langsWithRatio []langWithRatio) []string {
+	sort.Sort(byRatio(langsWithRatio))
 
 	var sortedLangs []string
-	for i := len(contentSizes) - 1; i >= 0; i-- {
-		sortedLangs = append(sortedLangs, reversedMap[contentSizes[i]]...)
+	for _, sortedLang := range langsWithRatio {
+		sortedLangs = append(sortedLangs, sortedLang.lang)
 	}
 	return sortedLangs
 }
 
-// SortLanguagesWithFloats32 sorts languages from the given map to a slice where the first one is with the highest number
-func SortLanguagesWithFloats32(langsWithSizes map[string]float32) []string {
-	var contentSizes []float64
-	reversedMap := make(map[float64][]string)
-	for lang, size32 := range langsWithSizes {
-		size := float64(size32)
-		if _, ok := reversedMap[size]; !ok {
-			contentSizes = append(contentSizes, size)
-		}
-		reversedMap[size] = append(reversedMap[size], lang)
-	}
-	sort.Float64s(contentSizes)
+type langWithRatio struct {
+	ratio float64
+	lang  string
+}
 
-	var sortedLangs []string
-	for i := len(contentSizes) - 1; i >= 0; i-- {
-		sortedLangs = append(sortedLangs, reversedMap[contentSizes[i]]...)
-	}
-	return sortedLangs
+type byRatio []langWithRatio
+
+func (a byRatio) Len() int      { return len(a) }
+func (a byRatio) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a byRatio) Less(i, j int) bool {
+	return a[i].ratio > a[j].ratio
 }

--- a/pkg/git/langs_test.go
+++ b/pkg/git/langs_test.go
@@ -21,6 +21,20 @@ func TestSortLanguagesWithInts(t *testing.T) {
 	assert.Equal(t, "Go", languages[2])
 }
 
+func TestSortLanguagesWithBiggerInts(t *testing.T) {
+	// given
+	langs := map[string]int{"Go": 345, "Java": 2345, "Ruby": 12345}
+
+	// when
+	languages := git.SortLanguagesWithInts(langs)
+
+	// then
+	require.Len(t, languages, 3)
+	assert.Equal(t, "Ruby", languages[0])
+	assert.Equal(t, "Java", languages[1])
+	assert.Equal(t, "Go", languages[2])
+}
+
 func TestSortLanguagesWithIntsWhenAllNumbersAreSame(t *testing.T) {
 	// given
 	langs := map[string]int{"Go": 1, "Java": 1, "Ruby": 1}
@@ -52,6 +66,20 @@ func TestSortLanguagesWithIntsWhenOneNumberIsBigger(t *testing.T) {
 func TestSortLanguagesWithFloats32(t *testing.T) {
 	// given
 	langs := map[string]float32{"Go": 1.9, "Java": 2.0, "Ruby": 2.0001}
+
+	// when
+	languages := git.SortLanguagesWithFloats32(langs)
+
+	// then
+	require.Len(t, languages, 3)
+	assert.Equal(t, "Ruby", languages[0])
+	assert.Equal(t, "Java", languages[1])
+	assert.Equal(t, "Go", languages[2])
+}
+
+func TestSortLanguagesWithBiggerFloats32(t *testing.T) {
+	// given
+	langs := map[string]float32{"Go": 3.45, "Java": 23.45, "Ruby": 123.45}
 
 	// when
 	languages := git.SortLanguagesWithFloats32(langs)


### PR DESCRIPTION
this PR fixes languages sorting - originally it sorted the languages by strings which didn't work in case of bigger numbers, eg:
```
Go : 123
Makefile: 23
```
as a result the Makefile was prior to the Go because the first number is bigger.
The cause of this mistake: a combination of lack of my brain activity with an attempt to avoid problems with duplicated ints/keys :-)