### PR TITLE
feat(ODC-469): when secret is not provided then default credentials are used

### DIFF
--- a/pkg/git/repository/generic/service_test.go
+++ b/pkg/git/repository/generic/service_test.go
@@ -20,11 +20,11 @@ func TestNewRepositoryServiceForAllSecretsAndMethods(t *testing.T) {
 	usernamePassword := git.NewUsernamePassword("anonymous", "")
 	oauthToken := git.NewOauthToken([]byte("some-token"))
 
-	for _, secret := range []git.Secret{sshKey, usernamePassword, oauthToken} {
+	for _, secret := range []git.Secret{sshKey, usernamePassword, oauthToken, nil} {
 		source := test.NewGitSource(test.WithURL(dummyRepo.Path))
 
 		// when
-		service, err := generic.NewRepositoryService(source, secret)
+		service, err := generic.NewRepositoryService(source, git.NewSecretProvider(secret))
 
 		// then
 		require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestNewRepositoryServiceShouldReturnFilesAddedByMultipleCommits(t *testing.
 
 	// when
 	service, err := generic.NewRepositoryService(source,
-		git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte("")))
+		git.NewSecretProvider(git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte(""))))
 
 	// then
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestNewRepositoryServiceWithEmptyMasterBranch(t *testing.T) {
 
 	// when
 	service, err := generic.NewRepositoryService(source,
-		git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte("")))
+		git.NewSecretProvider(git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte(""))))
 
 	// then
 	require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestNewRepositoryServiceWithOtherThanMasterBranch(t *testing.T) {
 
 	// when
 	service, err := generic.NewRepositoryService(source,
-		git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte("")))
+		git.NewSecretProvider(git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte(""))))
 
 	// then
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestNewRepositoryServiceShouldLoadFilesOnlyOnce(t *testing.T) {
 	source := test.NewGitSource(test.WithURL(dummyRepo.Path))
 
 	service, err := generic.NewRepositoryService(source,
-		git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte("")))
+		git.NewSecretProvider(git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte(""))))
 	require.NoError(t, err)
 
 	// when
@@ -152,7 +152,7 @@ func TestNewRepositoryServiceUsingSSh(t *testing.T) {
 	source := test.NewGitSource(test.WithURL("ssh://git@localhost:2222" + dummyRepo.Path))
 
 	service, err := generic.NewRepositoryService(source,
-		git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte("")))
+		git.NewSecretProvider(git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte(""))))
 	require.NoError(t, err)
 
 	// when
@@ -179,7 +179,7 @@ func TestNewRepositoryServiceUsingSShWithWrongKey(t *testing.T) {
 	source := test.NewGitSource(test.WithURL("ssh://git@localhost:2222" + dummyRepo.Path))
 
 	service, err := generic.NewRepositoryService(source,
-		git.NewSshKey(test.PrivateWithPassphrase(t, pathToTestDir), []byte("secret")))
+		git.NewSecretProvider(git.NewSshKey(test.PrivateWithPassphrase(t, pathToTestDir), []byte("secret"))))
 	require.NoError(t, err)
 
 	// when
@@ -207,7 +207,7 @@ func TestNewRepositoryServiceUsingBasicSShAuth(t *testing.T) {
 	for _, secret := range []git.Secret{usernamePassword, oauthToken} {
 		source := test.NewGitSource(test.WithURL("ssh://git@localhost:2222" + dummyRepo.Path))
 
-		service, err := generic.NewRepositoryService(source, secret)
+		service, err := generic.NewRepositoryService(source, git.NewSecretProvider(secret))
 		require.NoError(t, err)
 
 		// when
@@ -236,7 +236,7 @@ func TestNewRepositoryServiceUsingBasicSShAuthWithWrongPassword(t *testing.T) {
 	for _, secret := range []git.Secret{usernamePassword, oauthToken} {
 		source := test.NewGitSource(test.WithURL("ssh://git@localhost:2222" + dummyRepo.Path))
 
-		service, err := generic.NewRepositoryService(source, secret)
+		service, err := generic.NewRepositoryService(source, git.NewSecretProvider(secret))
 		require.NoError(t, err)
 
 		// when

--- a/pkg/git/repository/github/service.go
+++ b/pkg/git/repository/github/service.go
@@ -24,8 +24,8 @@ type RepositoryService struct {
 // NewRepoServiceIfMatches returns function creating Github repository service if either host of the git repo URL is github.com
 // or flavor of the given git source is github then, nil otherwise
 func NewRepoServiceIfMatches() repository.ServiceCreator {
-	return func(gitSource *v1alpha1.GitSource, secret git.Secret) (repository.GitService, error) {
-		if secret.SecretType() == git.SshKeyType {
+	return func(gitSource *v1alpha1.GitSource, secretProvider *git.SecretProvider) (repository.GitService, error) {
+		if secretProvider.SecretType() == git.SshKeyType {
 			return nil, nil
 		}
 		endpoint, err := gittransport.NewEndpoint(gitSource.Spec.URL)
@@ -33,6 +33,7 @@ func NewRepoServiceIfMatches() repository.ServiceCreator {
 			return nil, err
 		}
 		if endpoint.Host == githubHost || gitSource.Spec.Flavor == githubFlavor {
+			secret := secretProvider.GetSecret(git.NewUsernamePassword("anonymous", ""))
 			return newGhService(gitSource, endpoint, secret)
 		}
 		return nil, nil

--- a/pkg/git/repository/github/service_test.go
+++ b/pkg/git/repository/github/service_test.go
@@ -30,18 +30,22 @@ const (
 }`
 )
 
-func TestRepositoryServiceForBothAuthMethodsSuccessful(t *testing.T) {
+var (
+	usernamePassword = git.NewUsernamePassword("anonymous", "")
+	oauthToken       = git.NewOauthToken([]byte("some-token"))
+	validSecrets     = []git.Secret{usernamePassword, oauthToken, nil}
+)
+
+func TestRepositoryServiceForAllValidAuthMethodsSuccessful(t *testing.T) {
 	// given
 	defer gock.OffAll()
-	usernamePassword := git.NewUsernamePassword("anonymous", "")
-	oauthToken := git.NewOauthToken([]byte("some-token"))
 
-	for _, secret := range []git.Secret{usernamePassword, oauthToken} {
+	for _, secret := range validSecrets {
 		mockGHCalls(t, repoIdentifier, "master", test.S("pom.xml", "mvnw"), test.S("Java", "Go"))
 		source := test.NewGitSource(test.WithURL(repoURL))
 
 		// when
-		service, err := github.NewRepoServiceIfMatches()(source, secret)
+		service, err := github.NewRepoServiceIfMatches()(source, git.NewSecretProvider(secret))
 
 		// then
 		require.NoError(t, err)
@@ -66,7 +70,7 @@ func TestNewRepoServiceIfMatchesShouldNotMatchWhenSshKey(t *testing.T) {
 
 	// when
 	service, err := github.NewRepoServiceIfMatches()(source,
-		git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte("")))
+		git.NewSecretProvider(git.NewSshKey(test.PrivateWithoutPassphrase(t, pathToTestDir), []byte(""))))
 
 	// then
 	assert.NoError(t, err)
@@ -78,7 +82,8 @@ func TestNewRepoServiceIfMatchesShouldNotMatchWhenGitLabHost(t *testing.T) {
 	source := test.NewGitSource(test.WithURL("gitlab.com/" + repoIdentifier))
 
 	// when
-	service, err := github.NewRepoServiceIfMatches()(source, git.NewOauthToken([]byte("some-token")))
+	service, err := github.NewRepoServiceIfMatches()(source,
+		git.NewSecretProvider(git.NewOauthToken([]byte("some-token"))))
 
 	// then
 	assert.NoError(t, err)
@@ -90,7 +95,8 @@ func TestNewRepoServiceIfMatchesShouldMatchWhenFlavorIsGitHub(t *testing.T) {
 	source := test.NewGitSource(test.WithURL("gitprivatehub.com/"+repoIdentifier), test.WithFlavor("github"))
 
 	// when
-	service, err := github.NewRepoServiceIfMatches()(source, git.NewOauthToken([]byte("some-token")))
+	service, err := github.NewRepoServiceIfMatches()(source,
+		git.NewSecretProvider(git.NewOauthToken([]byte("some-token"))))
 
 	// then
 	assert.NoError(t, err)
@@ -102,7 +108,8 @@ func TestNewRepoServiceIfMatchesShouldNotFailWhenSsh(t *testing.T) {
 	source := test.NewGitSource(test.WithURL("git@github.com:" + repoIdentifier))
 
 	// when
-	service, err := github.NewRepoServiceIfMatches()(source, git.NewOauthToken([]byte("some-token")))
+	service, err := github.NewRepoServiceIfMatches()(source,
+		git.NewSecretProvider(git.NewOauthToken([]byte("some-token"))))
 
 	// then
 	assert.NoError(t, err)
@@ -112,10 +119,8 @@ func TestNewRepoServiceIfMatchesShouldNotFailWhenSsh(t *testing.T) {
 func TestRepositoryServiceForWrongRepo(t *testing.T) {
 	// given
 	defer gock.OffAll()
-	usernamePassword := git.NewUsernamePassword("anonymous", "")
-	oauthToken := git.NewOauthToken([]byte("some-token"))
 
-	for _, secret := range []git.Secret{usernamePassword, oauthToken} {
+	for _, secret := range validSecrets {
 		gock.New("https://api.github.com").
 			Get(fmt.Sprintf("/repos/%s/.*", repoIdentifier)).
 			Times(2).
@@ -124,7 +129,7 @@ func TestRepositoryServiceForWrongRepo(t *testing.T) {
 		source := test.NewGitSource(test.WithURL(repoURL), test.WithRef("dev"))
 
 		// when
-		service, err := github.NewRepoServiceIfMatches()(source, secret)
+		service, err := github.NewRepoServiceIfMatches()(source, git.NewSecretProvider(secret))
 
 		// then
 		require.NoError(t, err)
@@ -144,10 +149,8 @@ func TestRepositoryServiceForWrongRepo(t *testing.T) {
 func TestRepositoryServiceReturningRateLimit(t *testing.T) {
 	// given
 	defer gock.OffAll()
-	usernamePassword := git.NewUsernamePassword("anonymous", "")
-	oauthToken := git.NewOauthToken([]byte("some-token"))
 
-	for _, secret := range []git.Secret{usernamePassword, oauthToken} {
+	for _, secret := range validSecrets {
 		gock.New("https://api.github.com").
 			Get(fmt.Sprintf("/repos/%s/.*", repoIdentifier)).
 			Times(2).
@@ -156,7 +159,7 @@ func TestRepositoryServiceReturningRateLimit(t *testing.T) {
 		source := test.NewGitSource(test.WithURL(repoURL))
 
 		// when
-		service, err := github.NewRepoServiceIfMatches()(source, secret)
+		service, err := github.NewRepoServiceIfMatches()(source, git.NewSecretProvider(secret))
 
 		// then
 		require.NoError(t, err)

--- a/pkg/git/repository/gitlab/service.go
+++ b/pkg/git/repository/gitlab/service.go
@@ -21,8 +21,8 @@ type RepositoryService struct {
 // NewRepoServiceIfMatches returns function creating Github repository service if either host of the git repo URL is gitlab.com
 // or flavor of the given git source is gitlab then, nil otherwise
 func NewRepoServiceIfMatches() repository.ServiceCreator {
-	return func(gitSource *v1alpha1.GitSource, secret git.Secret) (repository.GitService, error) {
-		if secret.SecretType() == git.SshKeyType {
+	return func(gitSource *v1alpha1.GitSource, secretProvider *git.SecretProvider) (repository.GitService, error) {
+		if secretProvider.SecretType() == git.SshKeyType {
 			return nil, nil
 		}
 		endpoint, err := gittransport.NewEndpoint(gitSource.Spec.URL)
@@ -31,6 +31,7 @@ func NewRepoServiceIfMatches() repository.ServiceCreator {
 		}
 
 		if endpoint.Host == gitlabHost || gitSource.Spec.Flavor == gitlabFlavor {
+			secret := secretProvider.GetSecret(git.NewOauthToken([]byte("")))
 			return newGhClient(gitSource, secret, endpoint)
 		}
 		return nil, nil

--- a/pkg/git/repository/service.go
+++ b/pkg/git/repository/service.go
@@ -13,10 +13,10 @@ type GitService interface {
 }
 
 // ServiceCreator creates an instance of GitService for the given v1alpha1.GitSource
-type ServiceCreator func(gitSource *v1alpha1.GitSource, secret git.Secret) (GitService, error)
+type ServiceCreator func(gitSource *v1alpha1.GitSource, secret *git.SecretProvider) (GitService, error)
 
 // NewGitService returns an instance of GitService for the given v1alpha1.GitSource. If no service is matched then returns nil
-func NewGitService(gitSource *v1alpha1.GitSource, secret git.Secret, serviceCreators []ServiceCreator) (GitService, error) {
+func NewGitService(gitSource *v1alpha1.GitSource, secret *git.SecretProvider, serviceCreators []ServiceCreator) (GitService, error) {
 
 	for _, creator := range serviceCreators {
 		detector, err := creator(gitSource, secret)

--- a/pkg/git/secret.go
+++ b/pkg/git/secret.go
@@ -14,6 +14,28 @@ import (
 	gitssh "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 )
 
+type SecretProvider struct {
+	secret Secret
+}
+
+func NewSecretProvider(secret Secret) *SecretProvider {
+	return &SecretProvider{secret: secret}
+}
+
+func (p *SecretProvider) GetSecret(defaultSecret Secret) Secret {
+	if p.secret == nil {
+		return defaultSecret
+	}
+	return p.secret
+}
+
+func (p *SecretProvider) SecretType() string {
+	if p.secret == nil {
+		return ""
+	}
+	return p.secret.SecretType()
+}
+
 type Secret interface {
 	// GitAuthMethod returns an instance of git AuthMethod for the secret
 	GitAuthMethod() (transport.AuthMethod, error)

--- a/pkg/git/secret_test.go
+++ b/pkg/git/secret_test.go
@@ -150,3 +150,27 @@ func TestNewUsernamePassword(t *testing.T) {
 	require.NoError(t, err)
 	assertBasicAuth(t, method, "username", "password")
 }
+
+func TestNewSecretProviderWithSecretSet(t *testing.T) {
+	// given
+	oauthToken := git.NewOauthToken([]byte("some-token"))
+	secretProvider := git.NewSecretProvider(oauthToken)
+
+	// when
+	secret := secretProvider.GetSecret(git.NewUsernamePassword("anonymous", ""))
+
+	// then
+	assert.Equal(t, oauthToken, secret)
+}
+
+func TestNewSecretProviderWithSecretNotSet(t *testing.T) {
+	// given
+	secretProvider := git.NewSecretProvider(nil)
+	usernamePassword := git.NewUsernamePassword("anonymous", "")
+
+	// when
+	secret := secretProvider.GetSecret(usernamePassword)
+
+	// then
+	assert.Equal(t, usernamePassword, secret)
+}

--- a/pkg/test/service.go
+++ b/pkg/test/service.go
@@ -40,7 +40,7 @@ func (s *DummyService) GetLanguageList() ([]string, error) {
 }
 
 func (s *DummyService) Creator() repository.ServiceCreator {
-	return func(gitSource *v1alpha1.GitSource, secret git.Secret) (service repository.GitService, e error) {
+	return func(gitSource *v1alpha1.GitSource, secretProvider *git.SecretProvider) (service repository.GitService, e error) {
 		if s.shouldFail {
 			return nil, fmt.Errorf("creation failed")
 		}


### PR DESCRIPTION
when secret is not provided then default credentials are used:
* GitHub
   * `username: "anonymous", password: ""`
* GitLab
   * `token: ""`
* Bitbucket
   * `token: ""`
* generic git
   * the `transport.AuthMethod` is set to nil so no authN is used