### PR TITLE
chore: use BuildEnvStats and types from devconsole-api

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -582,14 +582,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8466f8f02821d01876c2955c59174503418869aac1fc6533cf20bddcd8dffbe4"
+  digest = "1:95d695afd835a6f3a2aa52e5cecf2307df2c86d23802a1557172a3b987688012"
   name = "github.com/redhat-developer/devconsole-api"
   packages = [
     "pkg/apis",
     "pkg/apis/devconsole/v1alpha1",
   ]
   pruneopts = "NT"
-  revision = "337a67c0dc928d5a01a9f48d989d5ac74ef26e92"
+  revision = "a67d77335e36554ccf3fea971af2d0ff10af3161"
 
 [[projects]]
   digest = "1:fcef1ce61da6f8f6f115154fb0e0e5b159fe11656839ba1e6061372711c013ee"

--- a/make/test.mk
+++ b/make/test.mk
@@ -106,7 +106,7 @@ test-unit-with-coverage: prebuild-check clean-coverage-unit $(COV_PATH_UNIT)
 test-unit: prebuild-check $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	ADMIN_LOG_LEVEL=$(ADMIN_LOG_LEVEL) go test -vet off $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	ADMIN_LOG_LEVEL=$(ADMIN_LOG_LEVEL) go test -vet off -p 1 $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
 
 .PHONY: test-e2e
 ## Runs the e2e tests without coverage
@@ -244,7 +244,7 @@ $(eval ALL_PKGS_COMMA_SEPARATED := $(6))
 @mkdir -p $(COV_DIR)/$(PACKAGE_NAME);
 $(eval COV_OUT_FILE := $(COV_DIR)/$(PACKAGE_NAME)/coverage.$(TEST_NAME).mode-$(COVERAGE_MODE))
 @$(ENV_VAR) ADMIN_LOG_LEVEL=$(ADMIN_LOG_LEVEL) \
-	go test -vet off $(PACKAGE_NAME) \
+	go test -vet off -p 1 $(PACKAGE_NAME) \
 		$(GO_TEST_VERBOSITY_FLAG) \
 		-coverprofile $(COV_OUT_FILE) \
 		-coverpkg $(ALL_PKGS_COMMA_SEPARATED) \

--- a/pkg/git/detector/detector.go
+++ b/pkg/git/detector/detector.go
@@ -21,17 +21,17 @@ var gitServiceCreators = []repository.ServiceCreator{
 
 // DetectBuildEnvironmentsWithSecret detects build tools and languages using the given secret in the git repository
 // defined by the given v1alpha1.GitSource
-func DetectBuildEnvironmentsWithSecret(gitSource *v1alpha1.GitSource, secret git.Secret) (*BuildEnvStats, error) {
+func DetectBuildEnvironmentsWithSecret(gitSource *v1alpha1.GitSource, secret git.Secret) (*v1alpha1.BuildEnvStats, error) {
 	return detectBuildEnvs(gitSource, git.NewSecretProvider(secret), gitServiceCreators)
 }
 
 // DetectBuildEnvironments detects build tools and languages using the default secret in the git repository
 // defined by the given v1alpha1.GitSource
-func DetectBuildEnvironments(gitSource *v1alpha1.GitSource) (*BuildEnvStats, error) {
+func DetectBuildEnvironments(gitSource *v1alpha1.GitSource) (*v1alpha1.BuildEnvStats, error) {
 	return detectBuildEnvs(gitSource, git.NewSecretProvider(nil), gitServiceCreators)
 }
 
-func detectBuildEnvs(gitSource *v1alpha1.GitSource, secretProvider *git.SecretProvider, serviceCreators []repository.ServiceCreator) (*BuildEnvStats, error) {
+func detectBuildEnvs(gitSource *v1alpha1.GitSource, secretProvider *git.SecretProvider, serviceCreators []repository.ServiceCreator) (*v1alpha1.BuildEnvStats, error) {
 	service, err := repository.NewGitService(gitSource, secretProvider, serviceCreators)
 	if err != nil {
 		return nil, err
@@ -45,10 +45,10 @@ func detectBuildEnvs(gitSource *v1alpha1.GitSource, secretProvider *git.SecretPr
 	return detectBuildEnvsUsingService(service)
 }
 
-func detectBuildEnvsUsingService(service repository.GitService) (*BuildEnvStats, error) {
+func detectBuildEnvsUsingService(service repository.GitService) (*v1alpha1.BuildEnvStats, error) {
 	var wg sync.WaitGroup
 	wg.Add(1)
-	detectedBuildTools := make(chan *DetectedBuildTool, len(BuildTools))
+	detectedBuildTools := make(chan *v1alpha1.DetectedBuildType, len(BuildTools))
 	var detectionErr error
 	go func() {
 		defer wg.Done()
@@ -64,20 +64,20 @@ func detectBuildEnvsUsingService(service repository.GitService) (*BuildEnvStats,
 		return nil, detectionErr
 	}
 
-	var environments []*DetectedBuildTool
+	var environments []v1alpha1.DetectedBuildType
 	for detectedBuildTool := range detectedBuildTools {
 		if detectedBuildTool != nil {
-			environments = append(environments, detectedBuildTool)
+			environments = append(environments, *detectedBuildTool)
 		}
 	}
 
-	return &BuildEnvStats{
+	return &v1alpha1.BuildEnvStats{
 		SortedLanguages:    languageList,
-		DetectedBuildTools: environments,
+		DetectedBuildTypes: environments,
 	}, nil
 }
 
-func detectBuildTools(service repository.GitService, detectedBuildTools chan *DetectedBuildTool) error {
+func detectBuildTools(service repository.GitService, detectedBuildTools chan *v1alpha1.DetectedBuildType) error {
 	var wg sync.WaitGroup
 	wg.Add(len(BuildTools))
 

--- a/pkg/git/detector/detector_whitebox_test.go
+++ b/pkg/git/detector/detector_whitebox_test.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"fmt"
+	"github.com/redhat-developer/devconsole-api/pkg/apis/devconsole/v1alpha1"
 	"github.com/redhat-developer/git-service/pkg/git/repository"
 	"github.com/redhat-developer/git-service/pkg/test"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestDetectBuildEnvsShouldUseGenericGitIfNotOtherMatches(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 2)
 
 	assertContainsBuildTool(t, buildTools, Maven, "pom.xml")
@@ -113,8 +114,8 @@ func TestBitbucketDetectorWithDefault(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	require.Len(t, buildEnvStats.DetectedBuildTools, 1)
-	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTools, Maven, "pom.xml")
+	require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
+	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, Maven, "pom.xml")
 	require.Len(t, buildEnvStats.SortedLanguages, 1)
 	assert.Equal(t, "java", buildEnvStats.SortedLanguages[0])
 }
@@ -128,8 +129,8 @@ func TestGitLabDetectorWithDefault(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	require.Len(t, buildEnvStats.DetectedBuildTools, 1)
-	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTools, Maven, "pom.xml")
+	require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
+	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, Maven, "pom.xml")
 	require.Len(t, buildEnvStats.SortedLanguages, 1)
 	assert.Equal(t, "Java", buildEnvStats.SortedLanguages[0])
 }
@@ -145,8 +146,8 @@ func TestGitHubDetectorWithDefault(t *testing.T) {
 	if err != nil {
 		assert.Contains(t, err.Error(), "API rate limit exceeded")
 	} else {
-		require.Len(t, buildEnvStats.DetectedBuildTools, 1)
-		assertContainsBuildTool(t, buildEnvStats.DetectedBuildTools, Maven, "pom.xml")
+		require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
+		assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, Maven, "pom.xml")
 		require.Len(t, buildEnvStats.SortedLanguages, 2)
 		assert.Equal(t, "Java", buildEnvStats.SortedLanguages[0])
 		assert.Equal(t, "Dockerfile", buildEnvStats.SortedLanguages[1])
@@ -162,8 +163,8 @@ func TestGenericGitUsingSshAccessingGitLabWithDefaultCredentials(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	require.Len(t, buildEnvStats.DetectedBuildTools, 1)
-	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTools, Maven, "pom.xml")
+	require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
+	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, Maven, "pom.xml")
 	require.Len(t, buildEnvStats.SortedLanguages, 6)
 	assert.Contains(t, buildEnvStats.SortedLanguages, "Java")
 }
@@ -177,8 +178,8 @@ func TestGenericGitUsingSshAccessingBitbucketWithDefaultCredentials(t *testing.T
 
 	// then
 	require.NoError(t, err)
-	require.Len(t, buildEnvStats.DetectedBuildTools, 1)
-	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTools, Maven, "pom.xml")
+	require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
+	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, Maven, "pom.xml")
 	require.Len(t, buildEnvStats.SortedLanguages, 6)
 	assert.Contains(t, buildEnvStats.SortedLanguages, "Java")
 }
@@ -192,8 +193,8 @@ func TestGenericGitUsingSshAccessingGitHubWithDefaultCredentials(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	require.Len(t, buildEnvStats.DetectedBuildTools, 1)
-	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTools, Maven, "pom.xml")
+	require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
+	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, Maven, "pom.xml")
 	require.Len(t, buildEnvStats.SortedLanguages, 6)
 	assert.Contains(t, buildEnvStats.SortedLanguages, "Java")
 }
@@ -270,9 +271,9 @@ func TestGitLabDetectorWithUsernamePassword(t *testing.T) {
 	printBuildEnvStats(buildEnvStats)
 }
 
-func printBuildEnvStats(buildEnvStats *BuildEnvStats) {
+func printBuildEnvStats(buildEnvStats *v1alpha1.BuildEnvStats) {
 	fmt.Println(buildEnvStats.SortedLanguages)
-	for _, build := range buildEnvStats.DetectedBuildTools {
-		fmt.Println(*build)
+	for _, build := range buildEnvStats.DetectedBuildTypes {
+		fmt.Println(build)
 	}
 }

--- a/pkg/git/detector/environment.go
+++ b/pkg/git/detector/environment.go
@@ -1,17 +1,9 @@
 package detector
 
-import "regexp"
-
-type BuildEnvStats struct {
-	SortedLanguages    []string
-	DetectedBuildTools []*DetectedBuildTool
-}
-
-type DetectedBuildTool struct {
-	language      string
-	name          string
-	detectedFiles []string
-}
+import (
+	"github.com/redhat-developer/devconsole-api/pkg/apis/devconsole/v1alpha1"
+	"regexp"
+)
 
 type BuildTool struct {
 	Language      string
@@ -19,11 +11,11 @@ type BuildTool struct {
 	ExpectedFiles []*regexp.Regexp
 }
 
-func NewDetectedBuildTool(language string, name string, detectedFiles []string) *DetectedBuildTool {
-	return &DetectedBuildTool{
-		language:      language,
-		name:          name,
-		detectedFiles: detectedFiles,
+func NewDetectedBuildTool(language string, name string, detectedFiles []string) *v1alpha1.DetectedBuildType {
+	return &v1alpha1.DetectedBuildType{
+		Language:      language,
+		Name:          name,
+		DetectedFiles: detectedFiles,
 	}
 }
 

--- a/pkg/git/detector/environment_whitebox_test.go
+++ b/pkg/git/detector/environment_whitebox_test.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"fmt"
+	"github.com/redhat-developer/devconsole-api/pkg/apis/devconsole/v1alpha1"
 	"github.com/redhat-developer/git-service/pkg/git/repository"
 	"github.com/redhat-developer/git-service/pkg/test"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +55,7 @@ func TestDetectJavaMavenAndGradle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 2)
 
 	assertContainsBuildTool(t, buildTools, Gradle, "gradlew")
@@ -76,7 +77,7 @@ func TestDetectJavaMavenAndGo(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 2)
 
 	assertContainsBuildTool(t, buildTools, Golang, "main.go")
@@ -99,7 +100,7 @@ func TestDetectRuby(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 1)
 
 	assertContainsBuildTool(t, buildTools, Ruby, "Gemfile")
@@ -120,7 +121,7 @@ func TestDetectPHP(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 1)
 
 	assertContainsBuildTool(t, buildTools, PHP, "index.php")
@@ -141,7 +142,7 @@ func TestDetectNodeJS(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 1)
 
 	assertContainsBuildTool(t, buildTools, NodeJS, "package.json", "gulpfile.js")
@@ -162,7 +163,7 @@ func TestDetectPython(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 1)
 
 	assertContainsBuildTool(t, buildTools, Python, "requirements.txt")
@@ -183,7 +184,7 @@ func TestDetectPerl(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 1)
 
 	assertContainsBuildTool(t, buildTools, Perl, "index.pl")
@@ -204,7 +205,7 @@ func TestDetectDotnet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTools
+	buildTools := buildEnvStats.DetectedBuildTypes
 	require.Len(t, buildTools, 1)
 
 	assertContainsBuildTool(t, buildTools, Dotnet, "project.json", "some.csproj")
@@ -214,14 +215,14 @@ func TestDetectDotnet(t *testing.T) {
 	assert.Equal(t, "C#", langs[0])
 }
 
-func assertContainsBuildTool(t *testing.T, detected []*DetectedBuildTool, expectedBuildTool BuildTool, files ...string) {
+func assertContainsBuildTool(t *testing.T, detected []v1alpha1.DetectedBuildType, expectedBuildTool BuildTool, files ...string) {
 	var found bool
 	for _, tool := range detected {
-		if tool.name == expectedBuildTool.Name {
-			assert.Equal(t, expectedBuildTool.Language, tool.language)
-			assert.Len(t, tool.detectedFiles, len(files))
+		if tool.Name == expectedBuildTool.Name {
+			assert.Equal(t, expectedBuildTool.Language, tool.Language)
+			assert.Len(t, tool.DetectedFiles, len(files))
 			for _, file := range files {
-				assert.Contains(t, tool.detectedFiles, file)
+				assert.Contains(t, tool.DetectedFiles, file)
 			}
 			found = true
 			break


### PR DESCRIPTION
* uses BuildEnvStats and DetectedBuildType from the `devconsole-api`
* disables parallel builds for tests because of conflicting ssh servers on the same port