### PR TITLE
Add api to get exposed container port from Dockerfile for Github/Bitbucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Get list of files exist in the repo
 ```sh
  const files = service.getRepoFileList();
 ```
+
+Detect Dockerfile in the repo
+```javascript
+ // This check returns boolean value
+ const isPresent = service.isDockerfilePresent();
+```
+
 Get Dockerfile content
 ```javascript 1.8
  const content = service.getDockerfileContent();

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Get list of files exist in the repo
 ```sh
  const files = service.getRepoFileList();
 ```
+Get Dockerfile content
+```javascript 1.8
+ const content = service.getDockerfileContent();
+```
+Get Exposed container
+```javascript
+ // Get dockerfile parser
+ const parser = new DockerFileParser(content);
+ // Get exposed container port
+ const containerPort = parser.getContainerPort(); 
+```
 
 ## Available scripts
 

--- a/__tests__/bitbucket_service_test.spec.ts
+++ b/__tests__/bitbucket_service_test.spec.ts
@@ -1,6 +1,7 @@
 import {GitSource, SecretType} from "../src/service/modal/gitsource";
 import {BitbucketService} from "../src/service/bitbucket_service";
 import {RepoFileList} from "../src/service/modal/response_model/repo_file_list";
+import {DockerFileParser} from "../src/dockerfile_parser/parser";
 
 describe('Bitbucket Service Tests', () => {
   it('should list all files of existing public bitbucket repo', (done: any) => {
@@ -38,4 +39,23 @@ describe('Bitbucket Service Tests', () => {
         done(err);
       });
   });
+
+  it('should return exposed container port', (done: any) => {
+    const gr = new GitSource(
+      "https://bitbucket.org/akashshinde123/tutorial-react-docker",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new BitbucketService(gr);
+    gs.getDockerfileContent()
+      .then((content: string) => {
+        const parser = new DockerFileParser(content);
+        const port = parser.getContainerPort();
+        expect(port).toEqual(5000);
+        done();
+      })
+      .catch((err: Error) => done(err))
+  });
+
 });

--- a/__tests__/bitbucket_service_test.spec.ts
+++ b/__tests__/bitbucket_service_test.spec.ts
@@ -58,4 +58,50 @@ describe('Bitbucket Service Tests', () => {
       .catch((err: Error) => done(err))
   });
 
+  it('should not return exposed container port', (done: any) => {
+    const gr = new GitSource(
+      "https://bitbucket.org/akshinde/testgitsource",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new BitbucketService(gr);
+    gs.getDockerfileContent()
+      .then((_: string) => {
+        done(new Error("This promise should have been rejected"));
+      })
+      .catch((err: Error) => {
+        expect(err).toBeDefined();
+        done();
+      })
+  });
+
+  it('should detect Dockerfile', (done: any) => {
+    const gr = new GitSource(
+      "https://bitbucket.org/akashshinde123/tutorial-react-docker",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new BitbucketService(gr);
+    gs.isDockerfilePresent().then((r: Boolean) => {
+      expect(r).toBe(true);
+      done();
+    }).catch((e:Error) => done(e))
+  });
+
+  it('should not detect Dockerfile', (done: any) => {
+    const gr = new GitSource(
+      "https://bitbucket.org/akshinde/testgitsource",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new BitbucketService(gr);
+    gs.isDockerfilePresent().then((r: Boolean) => {
+      expect(r).toBe(false);
+      done();
+    }).catch((e: Error) => done(e))
+  });
+
 });

--- a/__tests__/github_service_test.ts
+++ b/__tests__/github_service_test.ts
@@ -1,6 +1,7 @@
 import {GitSource, SecretType} from "../src/service/modal/gitsource";
 import {GithubService} from "../src/service/github_service";
 import * as assert from "assert";
+import {DockerFileParser} from "../src/dockerfile_parser/parser";
 
 describe("Github Tests" , () => {
   // Read more about fake timers: http://facebook.github.io/jest/docs/en/timer-mocks.html#content
@@ -113,6 +114,24 @@ describe("Github Tests" , () => {
         assert.fail("Failed to detect build type");
         done(err);
       })
+  });
+
+  it('should return exposed container port', (done: any) => {
+    const gr = new GitSource(
+      "https://github.com/mikesparr/tutorial-react-docker",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new GithubService(gr);
+    gs.getDockerfileContent()
+      .then((content: string) => {
+        const parser = new DockerFileParser(content);
+        const port = parser.getContainerPort();
+        expect(port).toEqual(5000);
+        done();
+      })
+      .catch((err: Error) => done(err))
   });
 
 });

--- a/__tests__/github_service_test.ts
+++ b/__tests__/github_service_test.ts
@@ -134,4 +134,31 @@ describe("Github Tests" , () => {
       .catch((err: Error) => done(err))
   });
 
+  it('should detect Dockerfile', (done: any) => {
+    const gr = new GitSource(
+      "https://github.com/mikesparr/tutorial-react-docker",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new GithubService(gr);
+    gs.isDockerfilePresent().then((r: Boolean) => {
+      expect(r).toBe(true);
+      done();
+    }).catch((e:Error) => done(e))
+  });
+
+  it('should not detect Dockerfile', (done: any) => {
+    const gr = new GitSource(
+      "https://github.com/redhat-developer/devconsole-git",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new GithubService(gr);
+    gs.isDockerfilePresent().then((r: Boolean) => {
+      expect(r).toBe(false);
+      done();
+    }).catch((e: Error) => done(e))
+  });
 });

--- a/src/build_type_detection/detector.ts
+++ b/src/build_type_detection/detector.ts
@@ -11,5 +11,5 @@ export function detectBuildType(files: string[]): BuildType[] {
     const matchedFiles = files.filter((f: string) => t.expectedRegexps.test(f));
     return <BuildType>{ buildType: t.name, language: t.language, files: matchedFiles };
   });
-  return buildTypes.filter(b => b.files.length > 0)
+  return buildTypes.filter((b: BuildType) => b.files.length > 0)
 }

--- a/src/client_test.ts
+++ b/src/client_test.ts
@@ -1,8 +1,13 @@
-import {DockerFileParser} from "./dockerfile_parser/parser";
+import {GitSource, SecretType} from "./service/modal/gitsource";
+import {BitbucketService} from "./service/bitbucket_service";
 
-const contents = 'FROM ubuntu:latest\n'
-  + 'ADD . /root\n'
-  + 'RUN echo done\n'
-  + 'EXPOSE 8080';
-const parser = new DockerFileParser(contents);
-parser.parse();
+const gr = new GitSource(
+  "https://bitbucket.org/akshinde/testgitsource",
+  SecretType.NO_AUTH,
+  null
+);
+
+const gs = new BitbucketService(gr);
+gs.getDockerfileContent()
+  .then(resp => console.log(resp))
+  .catch(err => console.error(err.message));

--- a/src/service/base_service.ts
+++ b/src/service/base_service.ts
@@ -35,6 +35,9 @@ import {ResponseLanguageList} from "./modal/response_model/language_list";
    // Returns source code tree for given gitsource
     abstract async getRepoFileList(): Promise<RepoFileList>;
 
+    // Checks if dockerfile exist in the repo and returns dockerfile content
+    abstract async getDockerfileContent(): Promise<string>;
+
    // Returns list of detected languages
    abstract async getRepoLanguageList(): Promise<ResponseLanguageList>;
 }

--- a/src/service/base_service.ts
+++ b/src/service/base_service.ts
@@ -38,6 +38,9 @@ import {ResponseLanguageList} from "./modal/response_model/language_list";
     // Checks if dockerfile exist in the repo and returns dockerfile content
     abstract async getDockerfileContent(): Promise<string>;
 
+    // Check if Dockerfile present in the repo.
+    abstract async isDockerfilePresent(): Promise<Boolean>;
+
    // Returns list of detected languages
    abstract async getRepoLanguageList(): Promise<ResponseLanguageList>;
 }

--- a/src/service/bitbucket_service.ts
+++ b/src/service/bitbucket_service.ts
@@ -7,6 +7,7 @@ import {RepoCheck} from "./modal/response_model/repo_check";
 import {Branch, BranchList} from "./modal/response_model/branch_list";
 import {RepoFileList} from "./modal/response_model/repo_file_list";
 import {ResponseLanguageList} from "./modal/response_model/language_list";
+import {__asyncDelegator} from "tslib";
 
 export class BitbucketService extends BaseService {
 
@@ -96,5 +97,20 @@ export class BitbucketService extends BaseService {
       }catch (e) {
         throw e;
       }
+    }
+
+    async getDockerfileContent(): Promise<string> {
+        try {
+          const metadata = this.getRepoMetadata();
+          const resp = await this.client.repositories.readSrc({
+            username: metadata.owner,
+            repo_slug: metadata.repoName,
+            path: 'Dockerfile',
+            node: metadata.defaultBranch,
+          });
+          return <string>resp.data;
+        }catch (e) {
+          throw e;
+        }
     }
 }

--- a/src/service/bitbucket_service.ts
+++ b/src/service/bitbucket_service.ts
@@ -7,7 +7,6 @@ import {RepoCheck} from "./modal/response_model/repo_check";
 import {Branch, BranchList} from "./modal/response_model/branch_list";
 import {RepoFileList} from "./modal/response_model/repo_file_list";
 import {ResponseLanguageList} from "./modal/response_model/language_list";
-import {__asyncDelegator} from "tslib";
 
 export class BitbucketService extends BaseService {
 

--- a/src/service/github_service.ts
+++ b/src/service/github_service.ts
@@ -103,4 +103,21 @@ export class GithubService extends BaseService {
       throw e;
     }
   }
+
+  async getDockerfileContent(): Promise<string> {
+      try {
+        const metadata = this.getRepoMetadata();
+        const resp = await this.client.repos.getContents({
+          owner: metadata.owner,
+          repo: metadata.repoName,
+          path: "Dockerfile"
+        });
+        if (resp.status == 200) {
+          return Buffer.from(resp.data.content, 'base64').toString();
+        }
+        throw new Error("Dockerfile doesn't exist in repo " + metadata.repoName)
+      }catch (e) {
+        throw e;
+      }
+  }
 }

--- a/src/service/github_service.ts
+++ b/src/service/github_service.ts
@@ -52,7 +52,7 @@ export class GithubService extends BaseService {
             const list = resp.data.map((r) => {
               return new Branch(r.name);
             });
-            return new BranchList(resp, list)
+          return new BranchList(resp, list)
         }catch (e) {
             throw e;
         }
@@ -119,5 +119,19 @@ export class GithubService extends BaseService {
       }catch (e) {
         throw e;
       }
+  }
+
+  async isDockerfilePresent(): Promise<Boolean> {
+    try {
+      const metadata = this.getRepoMetadata();
+      const resp = await this.client.repos.getContents({
+        owner: metadata.owner,
+        repo: metadata.repoName,
+        path: "Dockerfile"
+      });
+      return resp.status == 200;
+    }catch (e) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
This PR adds support to fetch Dockerfile content using Github and Bitbucket rest api.

### Usage

Get Dockerfile content
```
 const content = gitservice.getDockerfileContent();
```
Get Exposed container port
```
 // Get dockerfile parser
 const parser = new DockerFileParser(content);
 // Get exposed container port
 const containerPort = parser.getContainerPort(); 
```