### PR TITLE
Add api to get exposed container port from Dockerfile for Gitlab.

### DIFF
--- a/__tests__/gitlab_service_test.ts
+++ b/__tests__/gitlab_service_test.ts
@@ -1,6 +1,7 @@
 import {GitSource, SecretType} from "../src/service/modal/gitsource";
 import {GitlabService} from "../src/service/gitlab_service";
 import * as assert from "assert";
+import {DockerFileParser} from "../src/dockerfile_parser/parser";
 
 describe("Gitlab Tests" , () => {
   // Read more about fake timers: http://facebook.github.io/jest/docs/en/timer-mocks.html#content
@@ -113,6 +114,52 @@ describe("Gitlab Tests" , () => {
         assert.fail("Failed to detect build type");
         done(err);
       })
+  });
+
+  it('should return exposed container port', (done: any) => {
+    const gr = new GitSource(
+      "https://gitlab.com/jpratik999/tutorial-react-docker.git",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new GitlabService(gr);
+    gs.getDockerfileContent()
+      .then((content: string) => {
+        const parser = new DockerFileParser(content);
+        const port = parser.getContainerPort();
+        expect(port).toEqual(5000);
+        done();
+      })
+      .catch((err: Error) => done(err))
+  });
+
+  it('should detect Dockerfile', (done: any) => {
+    const gr = new GitSource(
+      "https://gitlab.com/jpratik999/tutorial-react-docker.git",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new GitlabService(gr);
+    gs.isDockerfilePresent().then((r: Boolean) => {
+      expect(r).toBe(true);
+      done();
+    }).catch((e:Error) => done(e))
+  });
+
+  it('should not detect Dockerfile', (done: any) => {
+    const gr = new GitSource(
+      "https://gitlab.com/jpratik999/devconsole-git.git",
+      SecretType.NO_AUTH,
+      null
+    );
+
+    const gs = new GitlabService(gr);
+    gs.isDockerfilePresent().then((r: Boolean) => {
+      expect(r).toBe(false);
+      done();
+    }).catch((e: Error) => done(e))
   });
 
 });

--- a/src/client_test.ts
+++ b/src/client_test.ts
@@ -1,13 +1,21 @@
 import {GitSource, SecretType} from "./service/modal/gitsource";
-import {BitbucketService} from "./service/bitbucket_service";
+import {GitlabService} from "./service/gitlab_service";
 
 const gr = new GitSource(
-  "https://bitbucket.org/akshinde/testgitsource",
+  "https://gitlab.com/jpratik999/devconsole-operator.git",
   SecretType.NO_AUTH,
-  null
+  ''
 );
 
-const gs = new BitbucketService(gr);
+const gs = new GitlabService(gr);
+
+//Expected output: true
+gs.isDockerfilePresent()
+  .then(resp => console.log(resp))
+  .catch(err => console.error(err.message));
+
+//Expected output: Dockerfile content
 gs.getDockerfileContent()
   .then(resp => console.log(resp))
   .catch(err => console.error(err.message));
+

--- a/src/client_test.ts
+++ b/src/client_test.ts
@@ -1,8 +1,9 @@
 import {GitSource, SecretType} from "./service/modal/gitsource";
 import {GitlabService} from "./service/gitlab_service";
+import {DockerFileParser} from "../src/dockerfile_parser/parser";
 
 const gr = new GitSource(
-  "https://gitlab.com/jpratik999/devconsole-operator.git",
+  "https://gitlab.com/jpratik999/tutorial-react-docker.git",
   SecretType.NO_AUTH,
   ''
 );
@@ -19,3 +20,9 @@ gs.getDockerfileContent()
   .then(resp => console.log(resp))
   .catch(err => console.error(err.message));
 
+//Expetcted output: container port
+gs.getDockerfileContent()
+  .then((content: string) => {
+    const parser = new DockerFileParser(content);
+    console.log(parser.getContainerPort());
+})

--- a/src/service/gitlab_service.ts
+++ b/src/service/gitlab_service.ts
@@ -60,7 +60,7 @@ export class GitlabService extends BaseService{
             return resp[i].id
           }
         }
-        throw new Error('Unable to find gitlab project id');
+        throw new Error('Unable to find gitlab project id, check project details!');
     }catch (e) {
         throw e;
     }
@@ -124,5 +124,24 @@ async getRepoBranchList(): Promise<BranchList> {
       throw e;
     }
   }
+
+  async getDockerfileContent(): Promise<string> {
+    try {
+      const projectID = await this.getProjectId();
+      return await this.client.RepositoryFiles.showRaw(projectID, 'Dockerfile', this.gitsource.ref)
+    }catch (e) {
+      throw e;
+    }
+}
+
+async isDockerfilePresent(): Promise<Boolean> {
+  try {
+    const projectID = await this.getProjectId();
+    await this.client.RepositoryFiles.showRaw(projectID, 'Dockerfile', this.gitsource.ref)
+    return true
+  }catch (e) {
+    return false
+  }
+}
 }
 


### PR DESCRIPTION
To test:
`npm start`
Expected output: 
`true`
`Dockerfile content`
`Container port`

All functions are `async` function so the sequence of output does not matter.

Output:
```
true
5000
FROM node:9.4

# Create app directory
WORKDIR /usr/src/app

# Expose port for service
EXPOSE 5000

# Install and configure `serve`.
RUN npm install -g serve

# Copy source code to image
COPY . .

# Install dependencies
RUN npm install

# Build app and start server from script
CMD ["/usr/src/app/run"]
```